### PR TITLE
Added login screen, passwd plugin and password storage file

### DIFF
--- a/nodemcu-sketches/shell/shell.lua
+++ b/nodemcu-sketches/shell/shell.lua
@@ -1,5 +1,38 @@
 -- shell
 do
+  local auth = {
+    authenticated = false,
+    username = "",
+    userlist = {},
+  }
+
+  local readpassfile = function()
+    if file.exists( "passwd" ) then
+      local done, size = false, 0
+      file.open( "passwd", "r" )
+      while not done do
+        local line = file.readline()
+        if line then
+          local u, p = string.match( line, "^([^%c:]+):(%w+)" )
+          if u and p then
+            auth.userlist[ u ] = p
+            size = size + 1
+          end
+        else
+          done = true
+        end
+      end
+      file.close()
+      if size == 0 then
+        auth.authenticated = true
+      else
+        auth.authenticated = false
+      end
+    else
+      auth.authenticated = true
+    end
+  end
+
   local esc = function( arg )
     local sgr = { r = 31, g = 32, b = 34, c = 36, m = 35, y = 33, k = 30, w = 37 }
     local code = sgr[ arg ] or 0
@@ -11,22 +44,37 @@ do
     return esc( "g" ) .. heap .." $ " .. esc()
   end
 
-  local shellfunc = function( cmdline )
-    local argv = {}
-    for arg in cmdline:gmatch( "%S+" ) do
-      table.insert( argv, arg )
-    end
-    if not argv[ 1 ] then
-      return
-    else
-      local luaplugin = "shell." .. argv[ 1 ] .. ".lua"
-      local lcplugin = "shell." .. argv[ 1 ] .. ".lc"
-      if file.exists( lcplugin ) then
-        dofile( lcplugin )( argv[ 2 ], argv[ 3 ], argv[ 4 ] )
-      elseif file.exists( luaplugin ) then
-        dofile( luaplugin )( argv[ 2 ], argv[ 3 ], argv[ 4 ] )
+  local shellfunc = function( cmdline, auth )
+    if not auth.authenticated then
+      auth.username = cmdline
+      coroutine.yield( "Password: " )
+      local pass
+      while not pass do
+        pass = coroutine.yield( "" )
+      end
+      if auth.userlist[ auth.username ] == crypto.toHex( crypto.hash( "sha1", pass ) ) then
+        auth.authenticated = true
+        auth.userlist = {}
       else
-        coroutine.yield( "Unknown command\n" )
+        coroutine.yield( "Authentication failed.\n" )
+      end
+    else
+      local argv = {}
+      for arg in string.gmatch( cmdline, "%S+" ) do
+        table.insert( argv, arg )
+      end
+      if not argv[ 1 ] then
+        return
+      else
+        local luaplugin = "shell." .. argv[ 1 ] .. ".lua"
+        local lcplugin = "shell." .. argv[ 1 ] .. ".lc"
+        if file.exists( lcplugin ) then
+          dofile( lcplugin )( argv[ 2 ], argv[ 3 ], argv[ 4 ] )
+        elseif file.exists( luaplugin ) then
+          dofile( luaplugin )( argv[ 2 ], argv[ 3 ], argv[ 4 ] )
+        else
+          coroutine.yield( "Unknown command\n" )
+        end
       end
     end
   end
@@ -35,9 +83,11 @@ do
   shell:listen( 23, function( lc )
     local cmd, ongoing, thread = {}, false, nil
     local respond = function( sc, req )
-      local state, str = coroutine.resume( thread, req )
+      local state, str = coroutine.resume( thread, req, auth )
       if state and str then
         sc:send( str )
+      elseif not auth.authenticated then
+        sc:close()
       elseif ongoing then
         sc:send( prompt() )
         ongoing = false
@@ -59,6 +109,11 @@ do
         end
       end
     end )
-    lc:send( prompt() )
+    readpassfile()
+    if not auth.authenticated then
+      lc:send( "login as: " )
+    else
+      lc:send( prompt() )
+    end
   end )
 end

--- a/nodemcu-sketches/shell/shell.passwd.lua
+++ b/nodemcu-sketches/shell/shell.passwd.lua
@@ -1,0 +1,105 @@
+-- passwd
+return function( username )
+  local userlist = {}
+
+  local readpassfile = function()
+    local done = false
+    file.open( "passwd", "r" )
+    while not done do
+      local line = file.readline()
+      if line then
+        local u, p = string.match( line, "^([^%c:]+):(%w+)" )
+        userlist[ u ] = p
+      else
+        done = true
+      end
+    end
+    file.close()
+  end
+
+  local savepassfile = function()
+    file.open( "passwd", "w" )
+    for u, p in pairs( userlist ) do
+      file.writeline( u .. ":" .. p )
+    end
+    file.close()
+  end
+
+  local ask = function( message )
+    local response
+    coroutine.yield( message )
+    while not response do
+      response = coroutine.yield( "" )
+    end
+    return response
+  end
+
+  local checkpassword = function( user, pass )
+    return userlist[ user ] == crypto.toHex( crypto.hash( "sha1", pass ) )
+  end
+
+  local asknewpassword = function()
+    local passnew = ask( "New password: " )
+    local passredo = ask( "Retype new password: " )
+    if passnew == passredo then
+      if passnew == "" then
+        return ""
+      else
+        return crypto.toHex( crypto.hash( "sha1", passnew ) )
+      end
+    else
+      coroutine.yield( "Failure: passwords do not match.\n" )
+    end
+  end
+
+  local addnewuser = function( user )
+    local answer = ask( string.format( "User '%s' is not found. Do you want to create him [y/N]? ", user ) )
+    if string.match( answer, "^[Yy]" ) then
+      local hash = asknewpassword()
+      if hash then
+        if hash == "" then
+          coroutine.yield( string.format( "Failure: unable to create user with empty password.\n" ) )
+        else
+          userlist[ user ] = hash
+          savepassfile()
+          coroutine.yield( string.format( "User '%s' created.\n", user ) )
+        end
+      end
+    end
+  end
+
+  if not username then
+    username = ask( "Username: " )
+  end
+
+  if file.exists( "passwd" ) then
+    readpassfile()
+    if userlist[ username ] then
+      local password = ask( "Old password: " )
+      if not checkpassword( username, password ) then
+        coroutine.yield( "Failure: wrong password.\n" )
+      else
+        coroutine.yield( string.format( "Changing password for '%s'.\n", username ) )
+        local hash = asknewpassword()
+        if hash then
+          if hash == "" then
+            local answer = ask( string.format( "Password is not set. Do you want to delete user '%s' [y/N]? ", username ) )
+            if string.match( answer, "^[Yy]" ) then
+              userlist[ username ] = nil
+              savepassfile()
+              coroutine.yield( string.format( "User '%s' deleted.\n", username ) )
+            end
+          else
+            userlist[ username ] = hash
+            savepassfile()
+            coroutine.yield( string.format( "Password for user '%s' updated.\n", username ) )
+          end
+        end
+      end
+    else
+      addnewuser( username )
+    end
+  else
+    addnewuser( username )
+  end
+end


### PR DESCRIPTION
- login/password pairs stored in passwd file;
- usernames are stored in open state, passwords - as SHA1 hashes;
- if there is no passwd file or it has no records, then auth is disabled
  and shell prompt immediately appears;
- if auth is enabled and you tried wrong combination - your connection
  will be closed;
- passwd tool can be used as password manager - it able change current
  password, add or delete user from database;
- if in passwd tool you selected nonexistent user, than you will be
  asked to create him or not;
- if in passwd tool you changed user's password to empty (just two
  returns on password prompts), then you will be asked to delete user or
  not.
